### PR TITLE
add option -e, -V; add pthread_join

### DIFF
--- a/src/dirbuster-ng_config.h
+++ b/src/dirbuster-ng_config.h
@@ -1,5 +1,6 @@
 #include <pthread.h>
 #include <stdio.h>
+#include "utils.h"
 
 typedef struct dbng_config {
 
@@ -15,5 +16,7 @@ typedef struct dbng_config {
   char* proxy_auth;
   char* http_auth;
   FILE* output_file;	
+  stringlist ext;
+  uint8_t verbose;
 
 } dbng_config;


### PR DESCRIPTION
Hey,

I made some changes to your code:
1.  Add a '-e' option, which allows me to specify file extensions like this:
 $ dirbuster-ng -e '.php,.zip,/,.html' -d ...
 (I guess you were meant to make it)
2. Add a '-V' option, which shows info for each request. This is useful for me sometimes, and I think it might be helpful for debugging.
3. Add pthread_join. Some weird error happens if we do not wait for the threads.

Any ideas??
